### PR TITLE
Fix bounding box intersection logic

### DIFF
--- a/gridtree/gridtree.py
+++ b/gridtree/gridtree.py
@@ -24,7 +24,9 @@ class NormalizedFloat(float):
         if 0 <= val <= 1:
             return val
         else:
-            raise ValueError(f'Not btetween 0 and 1 (inclusive): `{val}`')
+            raise ValueError(
+                f'Not between 0 and 1 (inclusive): `{val}`'
+            )
 
 
 class GTree:
@@ -33,7 +35,7 @@ class GTree:
         self._max_leaf_size = PositiveInt(max_leaf_size)
 
     def __repr__(self):
-        return f'Gtree(max_leaf_size={self._max_leaf_size})'
+        return f'GTree(max_leaf_size={self._max_leaf_size})'
 
     def _gtree(
             self,
@@ -134,13 +136,18 @@ def _reduce_bbox(bbox, index, level):
     low_cell = tuple(i * cell_width for i in index)
     high_cell = tuple(x_i + cell_width for x_i in low_cell)
     low_bbox, high_bbox = bbox
-    if low_cell > high_bbox:
-        return None
-    else:
-        return (
-            tuple(max(x_i1, x_i2) for x_i1, x_i2 in zip(low_cell, low_bbox)),
-            tuple(min(x_i1, x_i2) for x_i1, x_i2 in zip(high_cell, high_bbox)),
+    intersects = not any(
+        (low_cell_i > high_bbox_i) or (high_cell_i < low_bbox_i)
+        for low_cell_i, high_cell_i, low_bbox_i, high_bbox_i in zip(
+            low_cell, high_cell, low_bbox, high_bbox
         )
+    )
+    if not intersects:
+        return None
+    return (
+        tuple(max(x_i1, x_i2) for x_i1, x_i2 in zip(low_cell, low_bbox)),
+        tuple(min(x_i1, x_i2) for x_i1, x_i2 in zip(high_cell, high_bbox)),
+    )
 
 
 def _get_point_index_for_level(point, level):

--- a/tests/test_gridtree.py
+++ b/tests/test_gridtree.py
@@ -366,3 +366,11 @@ class TestFindInRadiusForListTree:
         found = find_in_radius(
                 list_tree, search_point=search_point, radius=0.3)
         assert found == expected_in_range
+
+
+def test_reduce_bbox_returns_none_when_no_intersection_in_higher_dimension():
+    from gridtree.gridtree import _reduce_bbox
+
+    bbox = ((0.7, 0.1), (0.8, 0.3))
+    assert _reduce_bbox(bbox, (0, 1), 1) is None
+


### PR DESCRIPTION
## Summary
- fix a typo in NormalizedFloat error message
- fix string in GTree.__repr__
- correct intersection check in `_reduce_bbox`
- add regression test for `_reduce_bbox`

## Testing
- `python -m pytest`
- `python -m mypy gridtree`
- `python -m flake8 gridtree` *(fails: No module named flake8)*
- `./bandit.sh` *(fails: No module named bandit)*
- `./spelling.sh` *(fails: aspell: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f804be3808333be16168fc860d315